### PR TITLE
Converted iawayback to an `ia` plugin.

### DIFF
--- a/ia_wayback.py
+++ b/ia_wayback.py
@@ -63,11 +63,15 @@ def checkURL(url):
     return(available, urlWayback, status, timestamp)
 
 def main(argv=None, session=None):
+    # Support for calling script directly, rather than through 'ia'.
+    if argv is None:
+        argv = ['wayback'] + sys.argv[1:]
+
+    # Parse args.
     args = docopt(__doc__, argv=argv)
 
-    url = args['<url>']
-    available, urlWayback, status, timestamp = checkURL(url)
-    print(','.join([url, str(available), urlWayback, status, timestamp]))
+    available, urlWayback, status, timestamp = checkURL(args['<url>'])
+    print(','.join([args['<url>'], str(available), urlWayback, status, timestamp]))
 
 if __name__ == '__main__':
     main()

--- a/ia_wayback.py
+++ b/ia_wayback.py
@@ -1,22 +1,37 @@
-# Simple, minimal Python wrapper around Internet Archive's Wayback Machine APIs:
-#
-# http://archive.org/help/wayback_api.php
-#
-# Check if user-specified URL was archived in Internet Archive's Wayback Machine.
-# CLI tool returns comma-delimited output with info on availability in Wayback
-# Archived URL (if available) is given for most recent snapshot only!
-#
-# Author: Johan van der Knijff
-#
+#!/usr/bin/env python
+"""Simple, minimal Python wrapper around Internet Archive's
+Wayback Machine APIs:
 
+    http://archive.org/help/wayback_api.php
+
+Check if user-specified URL was archived in Internet Archive's
+Wayback Machine. CLI tool returns comma-delimited output with info on
+availability in Wayback Archived URL (if available) is given for most
+recent snapshot only!
+
+Usage: ia wayback [--help] <url>
+
+Options:
+  -h, --help                Show this help message and exit.
+"""
 import sys
 import urllib2
 import json
 
+from docopt import docopt
+
+
+__title__ = 'ia_plugin'
+__version__ = '0.0.1'
+__url__ = 'https://github.com/jjjake/iawayback'
+__author__ = 'Johan van der Knijff'
+__all__ = ['ia_wayback']
+
+
 def checkURL(url):
 
     # API url (see: http://archive.org/help/wayback_api.php)
-    urlAPI="http://archive.org/wayback/available?url="
+    urlAPI="https://archive.org/wayback/available?url="
 
     # URL we want to search for
     urlSearch = url
@@ -47,17 +62,12 @@ def checkURL(url):
     
     return(available, urlWayback, status, timestamp)
 
-def main():
-    
-    if len(sys.argv) == 1:
-        sys.stderr.write("USAGE: iawayback.py <url> \n")
-        sys.exit()
+def main(argv=None, session=None):
+    args = docopt(__doc__, argv=argv)
 
-    url = sys.argv[1]
-
+    url = args['<url>']
     available, urlWayback, status, timestamp = checkURL(url)
-    stringOut = url + "," + str(available) + "," + urlWayback + "," + status + "," + timestamp
-    sys.stdout.write(stringOut + "\n")
+    print(','.join([url, str(available), urlWayback, status, timestamp]))
 
-main()
-
+if __name__ == '__main__':
+    main()

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
-# iawayback
+# IA command-line tool wayback plugin.
 
 ## About
-Iawayback is a simple, minimal Python wrapper around Internet Archive's Wayback Machine APIs, which are described here:
+`ia_wayback` is a simple, minimal Python wrapper around Internet Archive's Wayback Machine APIs, which are described here:
 
 <http://archive.org/help/wayback_api.php>
 
@@ -17,7 +17,7 @@ For now the functionality is limited to a check if a user-specified URL is avail
 
 ### Usage
 
-    usage: iawayback.py <url>
+    usage: ia_wayback.py <url>
 
 ### Positional arguments
 
@@ -25,7 +25,7 @@ For now the functionality is limited to a check if a user-specified URL is avail
 
 ## Example 1
 
-    iawayback.py www.projectmoonbase.com
+    ia_wayback.py www.projectmoonbase.com
 
 Which gives the following output:
 
@@ -33,7 +33,7 @@ Which gives the following output:
 
 ## Example 2
 
-    iawayback.py http://www.bitsgalore.org/2014/11/13/Demise-Of-Dutch-Blogosphere/
+    ia_wayback.py http://www.bitsgalore.org/2014/11/13/Demise-Of-Dutch-Blogosphere/
 
 This results in:
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+
+setup(
+    name='ia_wayback',
+    version='0.0.1',
+    author='Johan van der Knijff',
+    url='https://github.com/jjjake/ia-wayback',
+    description=('A simple, minimal Python wrapper around '
+                 'Internet Archive\'s Wayback Machine APIs'),
+    py_modules=['ia_wayback', 'docopt'],
+    install_requires=['internetarchive'],
+    entry_points={
+        'internetarchive.cli.plugins': [
+            'ia_wayback = ia_wayback',
+        ],
+        'console_scripts': [
+            'ia-wayback = ia_wayback:main',
+        ],
+    },
+    tests_require=[
+        'pytest',
+        'pytest-pep8',
+    ],
+)


### PR DESCRIPTION
I converted `iawayback` to an [ia command-line tool](https://github.com/jjjake/internetarchive) plugin.

The `ia_wayback.py` script is still callable directly. Note that `ia` plugins are supported in version >= 1.0.0. So, for now, you'll have to install `internetarchive` from github first:

```
pip install 'git+git://github.com/jjjake/internetarchive.git@master'
```

Then install the ia_wayback plugin:

```
pip install 'git+git://github.com/jjjake/iawayback.git@master'
```

And, start using `ia wayback <url>`.

Feel free to reject this pull request, I just wanted to use your iawayback repo as an example of how one might write a plugin for `ia`.

Here's another example of how to create a plugin for `ia`: https://github.com/jjjake/ia_plugin
